### PR TITLE
Fixed Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You're welcome to clone and self-host the application if you're so inclined.  Fo
     GITHUB_CLIENT_ID=youridhere
     GITHUB_CLIENT_SECRET=yoursecrethere
     GITHUB_CALLBACK_URL=http://yourdomain.com/github_callback
-    SECRET_TOKEN=some_token # should be at least 128 random chars
+    SECRET_KEY_TOKEN=some_token # should be at least 128 random chars
 
 If you're developing locally with WEBrick or similar, your domain in the callback URL should include the port, i.e.
 


### PR DESCRIPTION
Hello 

So I found this small typo the readme: 

`README.md` 
```
  GITHUB_CLIENT_ID=youridhere
  GITHUB_CLIENT_SECRET=yoursecrethere
  GITHUB_CALLBACK_URL=http://yourdomain.com/github_callback
  SECRET_TOKEN=some_token # should be at least 128 random chars
```

`SECRET_TOKEN` should be changed to `SECRET_KEY_TOKEN` because in the file 

`secret_token.rb` 

```
GitReports::Application.config.secret_key_base = ENV['SECRET_KEY_TOKEN']
```

ENV is set to SECRET_KEY_TOKEN. 

-Thank you. 

