### PR TITLE
Scottx611x/include submitter emails in notifications

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -76,9 +76,10 @@ class RepositoriesController < ApplicationController
   private
 
   def repository_params
-    params[:repository].permit(:display_name, :issue_name, :prompt, :followup, :labels, :allow_issue_title).merge(
+    params[:repository].permit(:display_name, :issue_name, :prompt, :followup, :labels, :allow_issue_title, :include_submitter_email).merge(
       notification_emails: parse_emails(params[:repository][:notification_emails]),
-      allow_issue_title: (params[:repository][:allow_issue_title] == 'yes')
+      allow_issue_title: (params[:repository][:allow_issue_title] == 'yes'),
+      include_submitter_email: (params[:repository][:include_submitter_email] == 'yes')
     )
   end
 

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,21 +1,21 @@
 class NotificationMailer < ActionMailer::Base
   default from: 'no-reply@gitreports.com'
 
-  def issue_submitted_email(repo_id, issue_id, submitter_info={})
+  def issue_submitted_email(repo_id, issue_id, submitter_info = {})
     defaults = {
-        @submitter_name => nil,
-        @submitter_email => nil
+      @submitter_name => nil,
+      @submitter_email => nil
     }
 
-    @submitter_info = defaults.merge(options)
+    @submitter_info = defaults.merge(submitter_info)
 
     @repository = Repository.find(repo_id)
     @issue_id = issue_id
 
     @subject = "New Issue Submitted to #{@repository.name}"
 
-    if @submitter_info[:submitter_name].present? and @submitter_info[:submitter_email].present?
-        @subject = "#{@subject} by #{@submitter_info[:submitter_name]}: #{@submitter_info[:submitter_email]}"
+    if @submitter_info[:submitter_name].present? && @submitter_info[:submitter_email].present?
+      @subject = "#{@subject} by #{@submitter_info[:submitter_name]}: #{@submitter_info[:submitter_email]}"
     end
 
     mail to: @repository.notification_emails, subject: @subject

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,10 +1,23 @@
 class NotificationMailer < ActionMailer::Base
   default from: 'no-reply@gitreports.com'
 
-  def issue_submitted_email(repo_id, issue_id)
+  def issue_submitted_email(repo_id, issue_id, submitter_info={})
+    defaults = {
+        @submitter_name => nil,
+        @submitter_email => nil
+    }
+
+    @submitter_info = defaults.merge(options)
+
     @repository = Repository.find(repo_id)
     @issue_id = issue_id
 
-    mail to: @repository.notification_emails, subject: "New Issue Submitted to #{@repository.name}"
+    @subject = "New Issue Submitted to #{@repository.name}"
+
+    if @submitter_info[:submitter_name].present? and @submitter_info[:submitter_email].present?
+        @subject = "#{@subject} by #{@submitter_info[:submitter_name]}: #{@submitter_info[:submitter_email]}"
+    end
+
+    mail to: @repository.notification_emails, subject: @subject
   end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -2,20 +2,13 @@ class NotificationMailer < ActionMailer::Base
   default from: 'no-reply@gitreports.com'
 
   def issue_submitted_email(repo_id, issue_id, submitter_info = {})
-    defaults = {
-      @submitter_name => nil,
-      @submitter_email => nil
-    }
-
-    @submitter_info = defaults.merge(submitter_info)
-
     @repository = Repository.find(repo_id)
     @issue_id = issue_id
 
     @subject = "New Issue Submitted to #{@repository.name}"
 
-    if @submitter_info[:submitter_name].present? && @submitter_info[:submitter_email].present?
-      @subject = "#{@subject} by #{@submitter_info[:submitter_name]}: #{@submitter_info[:submitter_email]}"
+    if submitter_info[:submitter_name].present? && submitter_info[:submitter_email].present?
+      @subject = "#{@subject} by #{submitter_info[:submitter_name]}: #{submitter_info[:submitter_email]}"
     end
 
     mail to: @repository.notification_emails, subject: @subject

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -45,7 +45,14 @@ class GithubService
       issue = create_issue(client, repo, issue_title, repo.construct_body(sub_name, email, email_public, details))
 
       # Send notification email
-      NotificationMailer.issue_submitted_email(repo.id, issue.number).deliver_later unless repo.notification_emails.blank?
+      if repo.notification_emails.present?
+        if repo.include_submitter_email
+          NotificationMailer.issue_submitted_email(repo.id, issue.number, {:submitter_name => sub_name, :submitter_email => email}).deliver_later
+
+        else
+          NotificationMailer.issue_submitted_email(repo.id, issue.number).deliver_later
+        end
+      end
 
       issue
     end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -47,7 +47,7 @@ class GithubService
       # Send notification email
       if repo.notification_emails.present?
         if repo.include_submitter_email
-          NotificationMailer.issue_submitted_email(repo.id, issue.number, :submitter_name => sub_name, :submitter_email => email).deliver_later
+          NotificationMailer.issue_submitted_email(repo.id, issue.number, submitter_name: sub_name, submitter_email: email).deliver_later
 
         else
           NotificationMailer.issue_submitted_email(repo.id, issue.number).deliver_later

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -47,7 +47,7 @@ class GithubService
       # Send notification email
       if repo.notification_emails.present?
         if repo.include_submitter_email
-          NotificationMailer.issue_submitted_email(repo.id, issue.number, {:submitter_name => sub_name, :submitter_email => email}).deliver_later
+          NotificationMailer.issue_submitted_email(repo.id, issue.number, :submitter_name => sub_name, :submitter_email => email).deliver_later
 
         else
           NotificationMailer.issue_submitted_email(repo.id, issue.number).deliver_later

--- a/app/views/repositories/edit.erb
+++ b/app/views/repositories/edit.erb
@@ -86,6 +86,28 @@
             </div>
           </div>
 
+          <% if @repository.notification_emails.present? %>
+            <div class="form-group">
+              <%= f.label :include_submitter_email %><br>
+              <p>
+                <i>Require submitters to include an email. If active, submitter emails will be included in email notifications.</i>
+              </p>
+
+              <div class="radio">
+                <label>
+                  <%= f.radio_button :include_submitter_email, 'no', :checked => !@repository.include_submitter_email %>
+                  No
+                </label>
+              </div>
+              <div class="radio">
+                <label>
+                  <%= f.radio_button :include_submitter_email, 'yes', :checked => @repository.include_submitter_email %>
+                  Yes
+                </label>
+              </div>
+            </div>
+          <% end %>
+
           <%= submit_tag "Update", class: "btn btn-primary" %>
         </div>
       </div>

--- a/app/views/repositories/repository.html.erb
+++ b/app/views/repositories/repository.html.erb
@@ -23,7 +23,7 @@
 
             <div class="form-group">
               <%= label :email, t('submit_form.label.email') %>
-              <%= email_field_tag :email, @email, class: 'form-control' %>
+              <%= email_field_tag :email, @email, class: 'form-control', :required => @repository.include_submitter_email %>
             </div>
 
             <div class="form-group">

--- a/app/views/repositories/show.erb
+++ b/app/views/repositories/show.erb
@@ -115,5 +115,11 @@
     <p>
       <b><%= @repository.allow_issue_title ? 'Yes' : 'No' %></b>: Users are <%= 'not' unless @repository.allow_issue_title %> permitted to set the issue title on GitHub.
     </p>
+    <h4>
+      Submitter Email Inclusion
+    </h4>
+    <p>
+      <b><%= @repository.include_submitter_email ? 'Yes' : 'No' %></b>: User emails are <%= 'not' unless @repository.include_submitter_email %> included in notification emails.
+    </p>
   </div>
 </div>

--- a/db/migrate/20170731231431_add_include_submitter_email_to_repositories.rb
+++ b/db/migrate/20170731231431_add_include_submitter_email_to_repositories.rb
@@ -1,0 +1,5 @@
+class AddIncludeSubmitterEmailToRepositories < ActiveRecord::Migration[5.1]
+  def change
+    add_column :repositories, :include_submitter_email, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 20170730214412) do
+ActiveRecord::Schema.define(version: 20170731231431) do
 
   create_table "organizations", force: :cascade do |t|
     t.string "name", limit: 255
@@ -40,6 +41,7 @@ ActiveRecord::Schema.define(version: 20170730214412) do
     t.string "owner", limit: 255
     t.string "notification_emails", limit: 255
     t.boolean "allow_issue_title", default: false
+    t.boolean "include_submitter_email", default: false
   end
 
   create_table "repositories_users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170730214412) do
 ActiveRecord::Schema.define(version: 20170731231431) do
 
   create_table "organizations", force: :cascade do |t|

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -8,12 +8,12 @@ describe NotificationMailer do
       expect(subject.body).to have_content('New issue submitted to repository CoolCode!')
     end
 
-    let!(:repository) { create :repository, name: 'CoolCode', owner: 'CoolOrg', notification_emails: 'joe@email.com', include_submitter_email: true}
+    let!(:repository) { create :repository, name: 'CoolCode', owner: 'CoolOrg', notification_emails: 'joe@email.com', include_submitter_email: true }
 
     subject { NotificationMailer.issue_submitted_email(repository.id, 1, submitter_name: 'Scott', submitter_email: 'Scott@Scott.com') }
 
     it 'sends notification mail with submitter information in subject' do
-      expect(subject).to have_content("Subject: New Issue Submitted to CoolCode by Scott: Scott@Scott.com")
+      expect(subject).to have_content('Subject: New Issue Submitted to CoolCode by Scott: Scott@Scott.com')
     end
   end
 end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -10,7 +10,7 @@ describe NotificationMailer do
 
     let!(:repository) { create :repository, name: 'CoolCode', owner: 'CoolOrg', notification_emails: 'joe@email.com', include_submitter_email: true}
 
-    subject { NotificationMailer.issue_submitted_email(repository.id, 1, {:submitter_name => "Scott", :submitter_email => "Scott@Scott.com"}) }
+    subject { NotificationMailer.issue_submitted_email(repository.id, 1, submitter_name: 'Scott', submitter_email: 'Scott@Scott.com') }
 
     it 'sends notification mail with submitter information in subject' do
       expect(subject).to have_content("Subject: New Issue Submitted to CoolCode by Scott: Scott@Scott.com")

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -7,5 +7,13 @@ describe NotificationMailer do
     it 'sends notification mail' do
       expect(subject.body).to have_content('New issue submitted to repository CoolCode!')
     end
+
+    let!(:repository) { create :repository, name: 'CoolCode', owner: 'CoolOrg', notification_emails: 'joe@email.com', include_submitter_email: true}
+
+    subject { NotificationMailer.issue_submitted_email(repository.id, 1, {:submitter_name => "Scott", :submitter_email => "Scott@Scott.com"}) }
+
+    it 'sends notification mail with submitter information in subject' do
+      expect(subject).to have_content("Subject: New Issue Submitted to CoolCode by Scott: Scott@Scott.com")
+    end
   end
 end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -1,19 +1,23 @@
 describe NotificationMailer do
   describe '#issue_submitted_email' do
-    let!(:repository) { create :repository, name: 'CoolCode', owner: 'CoolOrg', notification_emails: 'joe@email.com' }
+    context 'when not including submitter email' do
+      let!(:repository) { create :repository, name: 'CoolCode', owner: 'CoolOrg', notification_emails: 'joe@email.com' }
 
-    subject { NotificationMailer.issue_submitted_email(repository.id, 1) }
+      subject { NotificationMailer.issue_submitted_email(repository.id, 1) }
 
-    it 'sends notification mail' do
-      expect(subject.body).to have_content('New issue submitted to repository CoolCode!')
+      it 'sends notification mail without submitter email' do
+        expect(subject.body).to have_content('New issue submitted to repository CoolCode!')
+      end
     end
 
-    let!(:repository) { create :repository, name: 'CoolCode', owner: 'CoolOrg', notification_emails: 'joe@email.com', include_submitter_email: true }
+    context 'when including submitter email' do
+      let!(:repository) { create :repository, name: 'CoolCode', owner: 'CoolOrg', notification_emails: 'joe@email.com', include_submitter_email: true }
 
-    subject { NotificationMailer.issue_submitted_email(repository.id, 1, submitter_name: 'Scott', submitter_email: 'Scott@Scott.com') }
+      subject { NotificationMailer.issue_submitted_email(repository.id, 1, submitter_name: 'Scott', submitter_email: 'Scott@Scott.com') }
 
-    it 'sends notification mail with submitter information in subject' do
-      expect(subject).to have_content('Subject: New Issue Submitted to CoolCode by Scott: Scott@Scott.com')
+      it 'sends notification mail with submitter information in subject' do
+        expect(subject).to have_content('Subject: New Issue Submitted to CoolCode by Scott: Scott@Scott.com')
+      end
     end
   end
 end

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -150,7 +150,8 @@ describe GithubService do
         # Should have queued notification mail
         expect(enqueued_jobs.size).to eq(1)
         expect(enqueued_jobs.first[:job]).to eq(ActionMailer::DeliveryJob)
-        expect(enqueued_jobs.first[:args]).to eq(['NotificationMailer', 'issue_submitted_email', 'deliver_now', 1, 1347, {"submitter_name"=>"Bob", "submitter_email"=>"bob@email.com", "_aj_symbol_keys"=>["submitter_name", "submitter_email"]}])
+        expect(enqueued_jobs.first[:args]).to eq(['NotificationMailer', 'issue_submitted_email', 'deliver_now', 1, 1347, 
+          submitter_name: 'Bob', submitter_email: 'bob@email.com', _aj_symbol_keys: %w(submitter_name submitter_email)])
       end
     end
 

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -140,6 +140,20 @@ describe GithubService do
       end
     end
 
+    context 'repository has configured notification mails and includes submitters emails in said notifications' do
+      let!(:repository) { create :repository, users: [user], notification_emails: 'joe@email.com', include_submitter_email: true }
+
+      it 'creates the issue and sends notification' do
+        issue = subject
+        expect(issue['body']).to eq("I'm having a problem with this.")
+
+        # Should have queued notification mail
+        expect(enqueued_jobs.size).to eq(1)
+        expect(enqueued_jobs.first[:job]).to eq(ActionMailer::DeliveryJob)
+        expect(enqueued_jobs.first[:args]).to eq(['NotificationMailer', 'issue_submitted_email', 'deliver_now', 1, 1347, {"submitter_name"=>"Bob", "submitter_email"=>"bob@email.com", "_aj_symbol_keys"=>["submitter_name", "submitter_email"]}])
+      end
+    end
+
     context 'repository has not configured notification mails' do
       let!(:repository) { create :repository, users: [user] }
 

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -150,8 +150,8 @@ describe GithubService do
         # Should have queued notification mail
         expect(enqueued_jobs.size).to eq(1)
         expect(enqueued_jobs.first[:job]).to eq(ActionMailer::DeliveryJob)
-        expect(enqueued_jobs.first[:args]).to eq(['NotificationMailer', 'issue_submitted_email', 'deliver_now', 1, 1347, 
-          'submitter_name': 'Bob', 'submitter_email': 'bob@email.com', '_aj_symbol_keys': %w(submitter_name submitter_email)])
+        expect(enqueued_jobs.first[:args]).to eq(['NotificationMailer', 'issue_submitted_email', 'deliver_now', 1, 1347,
+                                                  'submitter_name' => 'Bob', 'submitter_email' => 'bob@email.com', '_aj_symbol_keys' => %w[submitter_name submitter_email]])
       end
     end
 

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -151,7 +151,7 @@ describe GithubService do
         expect(enqueued_jobs.size).to eq(1)
         expect(enqueued_jobs.first[:job]).to eq(ActionMailer::DeliveryJob)
         expect(enqueued_jobs.first[:args]).to eq(['NotificationMailer', 'issue_submitted_email', 'deliver_now', 1, 1347, 
-          submitter_name: 'Bob', submitter_email: 'bob@email.com', _aj_symbol_keys: %w(submitter_name submitter_email)])
+          'submitter_name': 'Bob', 'submitter_email': 'bob@email.com', '_aj_symbol_keys': %w(submitter_name submitter_email)])
       end
     end
 


### PR DESCRIPTION
- Add configurable `include_submitter_email` setting to send submitter emails in the subject of notification emails
- Fixes #119 

@schneidmaster This is also my first time touching ruby, so I'm probably doing something weird (Codeclimate and CI were helpful though, thanks for that)