### PR TITLE
Dockerize gitreports.com

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,34 @@
 FROM ruby:2.4.5
 
+# Install redis, sudo, nodejs, and yarn
+RUN apt-get update && apt-get -y install redis-server sudo
+RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+RUN sudo apt-get install -y nodejs
+RUN npm install -g yarn
+
+# Set up working dir
 RUN mkdir /app
 WORKDIR /app
 
 # Install gems
 RUN gem install foreman
-ADD Gemfile Gemfile.lock /app/
-RUN bundle install -j 8
-
-# Copy app files
-ADD . /app
-
-# Install redis, sudo, nodejs, and yarn
-RUN apt-get update && apt-get -y install redis-server && apt-get install -y sudo
-RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
-RUN sudo apt-get install -y nodejs
-RUN npm install -g yarn
 
 # Install app dependencies
-RUN yarn install
+COPY Gemfile Gemfile.lock /app/
 RUN bundle
-RUN rake db:migrate
+RUN bundle install -j 8
+COPY package.json yarn.lock /app/
+RUN yarn install
+
+# Copy app files
+COPY . /app/
 
 # Expose port 5000 from within the container to the world
 EXPOSE 5000
+EXPOSE 3808
+
+ENV HOST 0.0.0.0
+ENV WEBPACK_DEV_HOST 0.0.0.0
 
 # Start the Rails and webpack servers
-CMD foreman start -f Procfile.dev
+CMD redis-server --daemonize yes && bundle exec rails db:migrate && foreman start -f Procfile.dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ADD . /app
 
 # Install redis, sudo, nodejs, and yarn
 RUN apt-get update && apt-get -y install redis-server && apt-get install -y sudo
-RUN curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
 RUN sudo apt-get install -y nodejs
 RUN npm install -g yarn
 
@@ -21,6 +21,9 @@ RUN npm install -g yarn
 RUN yarn install
 RUN bundle
 RUN rake db:migrate
+
+# Expose port 5000 from within the container to the world
+EXPOSE 5000
 
 # Start the Rails and webpack servers
 CMD foreman start -f Procfile.dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM ruby:2.4.5
+
+RUN mkdir /app
+WORKDIR /app
+
+# Install gems
+RUN gem install foreman
+ADD Gemfile Gemfile.lock /app/
+RUN bundle install -j 8
+
+# Copy app files
+ADD . /app
+
+# Install redis, sudo, nodejs, and yarn
+RUN apt-get update && apt-get -y install redis-server && apt-get install -y sudo
+RUN curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+RUN sudo apt-get install -y nodejs
+RUN npm install -g yarn
+
+# Install app dependencies
+RUN yarn install
+RUN bundle
+RUN rake db:migrate
+
+# Start the Rails and webpack servers
+CMD foreman start -f Procfile.dev


### PR DESCRIPTION
Trying to Dockerize gitreports.com to make it easy to self-host

To run:

```
docker build -t testgit .
```

Then you can run:

```
docker run -ti -p 5000:5000 -p 3808:3808 testgit
```

And the service will be available at `http://localhost:5000`