### PR TITLE
Fix #129: Remove no-resize class to allow Details field to auto-resize

### DIFF
--- a/app/views/issues/new.html.erb
+++ b/app/views/issues/new.html.erb
@@ -40,7 +40,7 @@
 
             <div class="form-group">
               <%= label_tag :details, t('submit_form.label.details') %>
-              <%= text_area_tag :details, @details, class: "form-control no-resize" %>
+              <%= text_area_tag :details, @details, class: "form-control" %>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Fix #129: Remove no-resize class to allow Details field to auto-resize