### PR TITLE
Bump up simple_catcha2 to 0.5.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,7 +227,7 @@ GEM
       redis-namespace (~> 1.5, >= 1.5.2)
     sidekiq-status (0.6.0)
       sidekiq (>= 2.7)
-    simple_captcha2 (0.4.3)
+    simple_captcha2 (0.5.0)
       rails (>= 4.1)
     simplecov (0.13.0)
       docile (~> 1.1.0)


### PR DESCRIPTION
I feel like this might or might not fix #235, who knows. But considering that the linked issue makes gitreports.com pretty much unusable and still hasn't been resolved this probably doesn't hurt. I haven't tested whether this actually fixes the issue due to (despite my best efforts) being unable to run the giterports.com environment properly in a local environment.